### PR TITLE
upgrade 【fixnum】 to fix dependency probleam of dartssh when upgrade 【…

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  fixnum: ^0.10.9
+  fixnum: ^1.0.0
   convert: ^3.0.0
 
 dev_dependencies:


### PR DESCRIPTION
…http】.

to support new version of xterm.dart.

xterm.dart:
	2.0 => 2.5.0-pre

dartssh:
	build_runner 1.4.0 => 2.1.1
	http 0.12.0 => 0.13.3

tweentnacl-dart:
	fixnum 0.10.9 => 1.0.0